### PR TITLE
regexp literals include prefix `#` and suffix option `i`

### DIFF
--- a/gauche-mode.el
+++ b/gauche-mode.el
@@ -372,14 +372,16 @@
      (1 (prog1 "< cn"
           (scheme-syntax-propertize-sexp-comment (point) end))))
     ;; regexps
-    ((rx "#"
-         (submatch-n 1 "/")
+    ((rx (submatch "#")
+         "/"
          (0+ (or (seq "\\" any)
                  (not (any "/\\"))
                  ))
-         (submatch-n 2 "/"))
-     (1 "\"")
-     (2 "\""))
+         (or (seq "/" (submatch "i"))
+             (submatch "/")))
+     (1 "| cn")
+     (2 "|")
+     (3 "|"))
     ;; R6RS inline hex escape
     ((rx "\\" (any "Xx") (1+ hex-digit) (submatch ";"))
      (1 "_"))

--- a/gauche-paredit.el
+++ b/gauche-paredit.el
@@ -59,18 +59,20 @@ Otherwise, insert a literal slash.
 "
   (interactive "P")
   (cond ((gauche-paredit-in-regexp-p)
-         (if (let* ((pair (paredit-string-start+end-points))
-                    (start (car pair))
-                    (end (cdr pair))
-                    (pos (point)))
-               (or (= pos
+         (let* ((pair (paredit-string-start+end-points))
+                (start (car pair))
+                (end (cdr pair))
+                (pos (point)))
+           (if (or (= pos
                       (if (= ?\/ (char-after end))
                           end
                         (1- end)))
                    (= pos
-                      (1+ start))))
-             (forward-char)
-           (insert ?\\ ?\/)))
+                      (1+ start)))
+               (forward-char)
+             (if (= pos end)
+                 (insert ?\/)
+               (insert ?\\ ?\/)))))
         ((paredit-in-comment-p)
          (insert ?\/))
         ((not (paredit-in-char-p))

--- a/gauche-paredit.el
+++ b/gauche-paredit.el
@@ -46,7 +46,10 @@
 
 (defun gauche-paredit-in-regexp-p ()
   (and (paredit-in-string-p)
-       (= ?\/ (char-after (car (paredit-string-start+end-points))))))
+       (let ((start (car (paredit-string-start+end-points))))
+         (string= "#/"
+                  (buffer-substring-no-properties start
+                                                  (+ 2 start))))))
 
 (defun gauche-paredit-slash (&optional n)
   "After `#`, insert pair of slashes.
@@ -56,7 +59,16 @@ Otherwise, insert a literal slash.
 "
   (interactive "P")
   (cond ((gauche-paredit-in-regexp-p)
-         (if (= (point) (cdr (paredit-string-start+end-points)))
+         (if (let* ((pair (paredit-string-start+end-points))
+                    (start (car pair))
+                    (end (cdr pair))
+                    (pos (point)))
+               (or (= pos
+                      (if (= ?\/ (char-after end))
+                          end
+                        (1- end)))
+                   (= pos
+                      (1+ start))))
              (forward-char)
            (insert ?\\ ?\/)))
         ((paredit-in-comment-p)


### PR DESCRIPTION
正規表現リテラルが最初の `#` と後置オプションを含むようにしてみました。
あわせて、`gauche-paredit-slash` も適当に動くようにしました。後置オプションの直前にpointがあるときの挙動が怪しいですが、paredit的にどう動くべきか分からないので怪しいままです。
github不慣れなので、それも含めて変な所があったらご指摘いただけると幸いです。