### PR TITLE
support char-set literal syntax

### DIFF
--- a/gauche-mode.el
+++ b/gauche-mode.el
@@ -382,6 +382,15 @@
      (1 "| cn")
      (2 "|")
      (3 "|"))
+    ;; SRFI-14 Character-set
+    ((rx (submatch "#")
+         "["
+         (0+ (or (seq "\\" any)
+                 (seq "[:" (0+ lower) ":]")
+                 (not (any "[]\\"))))
+         (submatch "]"))
+     (1 "| cn")
+     (2 "|"))
     ;; R6RS inline hex escape
     ((rx "\\" (any "Xx") (1+ hex-digit) (submatch ";"))
      (1 "_"))


### PR DESCRIPTION
`gauche-syntax-propertize` に文字集合リテラルを追加しましょう。これで多分Gaucheのリテラル類をカバーできるので、`|` の構文クラスを汎用文字列区切りにできると思います。lisp-modeのように。