### PR TITLE
adjust calls to scheme-syntax-propertize-sexp-comment

### DIFF
--- a/gauche-mode.el
+++ b/gauche-mode.el
@@ -221,13 +221,13 @@
 
 (defun gauche-syntax-propertize (beg end)
   (goto-char beg)
-  (scheme-syntax-propertize-sexp-comment (point) end)
+  (scheme-syntax-propertize-sexp-comment end)
   (funcall
    (syntax-propertize-rules
     ;; sexp comments
     ((rx (submatch "#") ";")
      (1 (prog1 "< cn"
-          (scheme-syntax-propertize-sexp-comment (point) end))))
+          (scheme-syntax-propertize-sexp-comment end))))
     ;; tokens that might be terminated by "#"
     ;; This avoids conflict with tokens start with "#". (e.g. "#\#//")
     ((rx (or (seq "#\\"


### PR DESCRIPTION
As of Emacs 30.1 (c4e7eec8c096219ddc6b3a981eef03ce421b8877) scheme-syntax-propertize-sexp-comment uses only one argument.